### PR TITLE
remove molvs dependency

### DIFF
--- a/vslib/prepare.py
+++ b/vslib/prepare.py
@@ -1,5 +1,7 @@
-from molvs.standardize import Standardizer
-from molvs.tautomer import TautomerCanonicalizer
+#from molvs.standardize import Standardizer
+#from molvs.tautomer import TautomerCanonicalizer
+from rdkit.Chem.MolStandardize import Standardizer
+from rdkit.Chem.MolStandardize.tautomer import TautomerCanonicalizer
 from rdkit.Chem import AllChem as Chem
 from rdkit.Chem import MACCSkeys
 from rdkit.Chem.AtomPairs import Pairs, Torsions

--- a/vslib/read.py
+++ b/vslib/read.py
@@ -3,8 +3,10 @@ import ssl
 from itertools import groupby
 from urllib.request import urlopen
 
-from molvs.standardize import Standardizer
-from molvs.tautomer import TautomerCanonicalizer, TautomerEnumerator
+#from molvs.standardize import Standardizer
+#from molvs.tautomer import TautomerCanonicalizer, TautomerEnumerator
+from rdkit.Chem.MolStandardize import Standardizer
+from rdkit.Chem.MolStandardize.tautomer import TautomerCanonicalizer, TautomerEnumerator
 from rdkit.Chem import AllChem as Chem
 from xlrd import open_workbook
 


### PR DESCRIPTION
Dear developper,

Recent version of rdkit supports molvs functionality. So I think it is better to remove molvs dependency from the code.
Thanks,

Taka